### PR TITLE
Slug

### DIFF
--- a/lib/hello_code/active_record_utils/concerns/sluggable.rb
+++ b/lib/hello_code/active_record_utils/concerns/sluggable.rb
@@ -13,7 +13,7 @@ module HelloCode
           scope :by_slug, ->(slug) { where(slug: slug) }
 
           # Slug must be present
-          validates :slug, presence: true, length: { maximum: 256 }
+          validates :slug, presence: true, uniqueness:true, length: { maximum: 256 }
         end
 
         module ClassMethods
@@ -40,17 +40,16 @@ module HelloCode
 
         def qualify_slug(base_slug)
           tentative_slug = base_slug
-          while duplicate_slug?(tentative_slug)
+          begin
             tentative_slug = generate_slug_name(base_slug)
-          end
+          end while duplicate_slug?(tentative_slug)
           tentative_slug
         end
 
         def duplicate_slug?(slug)
           self.class
             .where.not(id: id)
-            .by_slug(slug)
-            .exists?
+            .exists?(slug: slug)
         end
 
         def generate_slug_name(slug)

--- a/lib/hello_code/active_record_utils/concerns/sluggable.rb
+++ b/lib/hello_code/active_record_utils/concerns/sluggable.rb
@@ -40,9 +40,9 @@ module HelloCode
 
         def qualify_slug(base_slug)
           tentative_slug = base_slug
-          begin
+          while duplicate_slug?(tentative_slug)
             tentative_slug = generate_slug_name(base_slug)
-          end while duplicate_slug?(tentative_slug)
+          end 
           tentative_slug
         end
 
@@ -53,7 +53,7 @@ module HelloCode
         end
 
         def generate_slug_name(slug)
-          "#{slug}-#{SecureRandom.random_number(10_000)}"
+          "#{slug}-#{SecureRandom.urlsafe_base64(4)}"
         end
       end
     end


### PR DESCRIPTION
Add `uniqueness: true` validation since it should always be unique.
Use `exists?(query)` for cleaner and better query outcome. 
If you put the `while` at the end of the loop you remove the +1 case of the first run having `tentative_slug` being duplicate before you generate it.